### PR TITLE
refactoring resolveConfigPath to resolvePathRelativeToConfig

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -80,7 +80,7 @@ class GraphQLProjectConfig {
   configPath: string
   projectName?: string
 
-  resolveConfigPath(relativePath: string): string // resolves path relative to config
+  resolvePathRelativeToConfig(relativePath: string): string
   includesFile(filePath: string): boolean
 
   getSchema(): GraphQLSchema

--- a/src/GraphQLProjectConfig.ts
+++ b/src/GraphQLProjectConfig.ts
@@ -49,9 +49,14 @@ export class GraphQLProjectConfig {
     this.projectName = projectName
   }
 
-  resolveConfigPath(relativePath: string): string {
+  resolvePathRelativeToConfig(relativePath: string): string {
     return resolve(this.configDir, relativePath)
   }
+
+  /**
+   * @deprecated use resolvePathRelativeToConfig
+   */
+  resolveConfigPath = this.resolvePathRelativeToConfig;
 
   includesFile(fileUri: string): boolean {
     const filePath = fileUri.startsWith('file://') ?
@@ -69,7 +74,7 @@ export class GraphQLProjectConfig {
 
   getSchema(): GraphQLSchema {
     if (this.schemaPath) {
-      return readSchema(this.resolveConfigPath(this.schemaPath))
+      return readSchema(this.resolvePathRelativeToConfig(this.schemaPath))
     }
     throw new Error(
       `"schemaPath" is required but not provided in ${this.configPath}`
@@ -90,7 +95,7 @@ export class GraphQLProjectConfig {
   }
 
   get schemaPath(): string | null {
-    return this.config.schemaPath ? this.resolveConfigPath(this.config.schemaPath) : null
+    return this.config.schemaPath ? this.resolvePathRelativeToConfig(this.config.schemaPath) : null
   }
 
   get includes(): string[] {


### PR DESCRIPTION
renaming `resolveConfigPath` to `resolvePathRelativeToConfig`.

This change is being requested because `resolveConfigPath` is a rather misleading name (enough so that I had written an identical function that was only removed once I read the source for `resolveConfigPath`). I left the original `resolveConfigPath` as an alias to the renamed function with a deprecation attribute attached to facilitate. I realize that this change is moderately opinionated, but I would rather get the PR posted and start a discussion since it's a relatively small change.