### PR TITLE
Remove graphql-request dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "typescript": "2.7.2"
   },
   "dependencies": {
+    "cross-fetch": "^3.0.2",
     "graphql-import": "^0.7.1",
-    "graphql-request": "^1.5.0",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.4",
     "minimatch": "^3.0.4"

--- a/src/GraphQLProjectConfig.ts
+++ b/src/GraphQLProjectConfig.ts
@@ -8,8 +8,6 @@ import {
   buildClientSchema,
 } from 'graphql'
 
-import { GraphQLClient } from 'graphql-request'
-
 import {
   IntrospectionResult,
   GraphQLResolvedConfigData,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,12 @@
 import { IntrospectionQuery } from 'graphql'
 import { GraphQLConfigEnpointsData } from './extensions/';
 
+export type Variables = { [key: string]: any }
+
+export interface Headers {
+  [key: string]: string
+}
+
 export type IntrospectionResult = {
   data: IntrospectionQuery
   extensions?: Object
@@ -23,4 +29,52 @@ export type GraphQLResolvedConfigData = {
 
 export type GraphQLConfigData = GraphQLResolvedConfigData & {
   projects?: { [projectName: string]: GraphQLResolvedConfigData }
+}
+
+export interface GraphQLError {
+  message: string
+  locations: { line: number, column: number }[]
+  path: string[]
+}
+
+export interface GraphQLResponse {
+  data?: any
+  errors?: GraphQLError[]
+  extensions?: any
+  status: number
+  [key: string]: any
+}
+
+export interface GraphQLRequestContext {
+  query: string
+  variables?: Variables
+}
+
+export class ClientError extends Error {
+
+  response: GraphQLResponse
+  request: GraphQLRequestContext
+
+  constructor (response: GraphQLResponse, request: GraphQLRequestContext) {
+    const message = `${ClientError.extractMessage(response)}: ${JSON.stringify({ response, request })}`
+
+    super(message)
+
+    this.response = response
+    this.request = request
+
+    // this is needed as Safari doesn't support .captureStackTrace
+    /* tslint:disable-next-line */
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, ClientError)
+    }
+  }
+
+  private static extractMessage (response: GraphQLResponse): string {
+    try {
+      return response.errors![0].message
+    } catch (e) {
+      return `GraphQL Error (Code: ${response.status})`
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,13 +1051,13 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-cross-fetch@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-1.1.1.tgz#dede6865ae30f37eae62ac90ebb7bdac002b05a0"
-  integrity sha512-+VJE04+UfxxmBfcnmAu/lKor53RUCx/1ilOti4p+JgrnLQ4AZZIRoe2OEd76VaHyWQmQxqKnV+TaqjHC4r0HWw==
+cross-fetch@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.2.tgz#b7136491967031949c7f86b15903aef4fa3f1768"
+  integrity sha512-a4Z0EJ5Nck6QtMy9ZqloLfpvu2uMV3sBfMCR+CgSBCZc6z5KR4bfEiD3dkepH8iZgJMXQpTqf8FjMmvu/GMFkg==
   dependencies:
-    node-fetch "1.7.3"
-    whatwg-fetch "2.0.3"
+    node-fetch "2.3.0"
+    whatwg-fetch "3.0.0"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -1206,13 +1206,6 @@ empower-core@^0.6.1:
   dependencies:
     call-signature "0.0.2"
     core-js "^2.0.0"
-
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
 
 equal-length@^1.0.0:
   version "1.0.1"
@@ -1570,13 +1563,6 @@ graphql-import@^0.7.1:
     lodash "^4.17.4"
     resolve-from "^4.0.0"
 
-graphql-request@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.5.0.tgz#69b30a1767189fcba27f5c907c0a87339f90b5d8"
-  integrity sha512-K65i5mZb9ti4O08fd9gJkWoaidDxj9JPQdkGWGIxiuDj9pHAmwPLpX0xCjBZKVp3//DOiYk1r52sXuqMF6Zoyg==
-  dependencies:
-    cross-fetch "1.1.1"
-
 graphql@14.0.2:
   version "14.0.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.0.2.tgz#7dded337a4c3fd2d075692323384034b357f5650"
@@ -1685,11 +1671,6 @@ hullabaloo-config-manager@^1.1.0:
     pkg-dir "^2.0.0"
     resolve-from "^3.0.0"
     safe-buffer "^5.0.1"
-
-iconv-lite@~0.4.13:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
-  integrity sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==
 
 ignore-by-default@^1.0.0:
   version "1.0.1"
@@ -1928,7 +1909,7 @@ is-retry-allowed@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
   integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -2342,13 +2323,10 @@ nan@^2.3.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
   integrity sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=
 
-node-fetch@1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
+node-fetch@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
+  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
 
 node-pre-gyp@^0.6.39:
   version "0.6.39"
@@ -3472,10 +3450,10 @@ well-known-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/well-known-symbols/-/well-known-symbols-1.0.0.tgz#73c78ae81a7726a8fa598e2880801c8b16225518"
   integrity sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg=
 
-whatwg-fetch@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
-  integrity sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=
+whatwg-fetch@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 which@^1.2.9:
   version "1.3.0"


### PR DESCRIPTION
* Project seems to be dead
* Allows other dependancies to be updated

Not sure if this is the best way.
I just plucked the relevant code from the other library. Both projects are MIT licensed, so this should be ok.