### PR TITLE
Add support for configuring tagNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You may specify the name of the template literal tag that is used when defining 
 
 ```json
 {
-  "tagName": "gql"
+  "tagNames": ["gql"],
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ or
 }
 ```
 
+### Specifying a tagged template name
+
+You may specify the name of the template literal tag that is used when defining GraphQL queries. The default is `gql`.
+
+```json
+{
+  "tagName": "gql"
+}
+```
+
 ### Specifying includes/excludes files
 
 You can specify which files are included/excluded using the corresponding options:

--- a/src/GraphQLProjectConfig.ts
+++ b/src/GraphQLProjectConfig.ts
@@ -105,6 +105,10 @@ export class GraphQLProjectConfig {
     return this.config.extensions || {}
   }
 
+  get tagName(): string {
+    return this.config.tagName || 'gql'
+  }
+
   /*
    extension related helper functions
   */

--- a/src/GraphQLProjectConfig.ts
+++ b/src/GraphQLProjectConfig.ts
@@ -105,8 +105,8 @@ export class GraphQLProjectConfig {
     return this.config.extensions || {}
   }
 
-  get tagName(): string {
-    return this.config.tagName || 'gql'
+  get tagNames(): string[] {
+    return this.config.tagNames || ['gql'];
   }
 
   /*

--- a/src/__tests__/basic/config/.graphqlconfig
+++ b/src/__tests__/basic/config/.graphqlconfig
@@ -3,6 +3,10 @@
     "testWithSchema": {
       "schemaPath": "__schema__/StarWarsSchema.graphql"
     },
+    "testWithTagName": {
+      "schemaPath": "__schema__/StarWarsSchema.graphql",
+      "tagName": "graphql"
+    },
     "testWithoutSchema": {
     },
     "testSchemaA": {

--- a/src/__tests__/basic/config/.graphqlconfig
+++ b/src/__tests__/basic/config/.graphqlconfig
@@ -3,9 +3,9 @@
     "testWithSchema": {
       "schemaPath": "__schema__/StarWarsSchema.graphql"
     },
-    "testWithTagName": {
+    "testWithTagNames": {
       "schemaPath": "__schema__/StarWarsSchema.graphql",
-      "tagName": "graphql"
+      "tagNames": ["graphql"]
     },
     "testWithoutSchema": {
     },

--- a/src/__tests__/basic/getGraphQLConfig.ts
+++ b/src/__tests__/basic/getGraphQLConfig.ts
@@ -16,6 +16,13 @@ test('returns a correct name', t => {
   t.deepEqual(testWithSchemaConfig.projectName, 'testWithSchema')
 })
 
+test("returns the correct tagName", t => {
+  const testWithSchemaConfig = config.getProjectConfig("testWithSchema")
+  t.deepEqual(testWithSchemaConfig.tagName, "gql")
+  const testWithTagNameConfig = config.getProjectConfig("testWithTagName")
+  t.deepEqual(testWithTagNameConfig.tagName, "graphql")
+})
+
 test('returns config for file', t => {
   const testWithSchemaConfig = config.getConfigForFile(
     resolve('./config/schema-a.graphql'),

--- a/src/__tests__/basic/getGraphQLConfig.ts
+++ b/src/__tests__/basic/getGraphQLConfig.ts
@@ -16,11 +16,11 @@ test('returns a correct name', t => {
   t.deepEqual(testWithSchemaConfig.projectName, 'testWithSchema')
 })
 
-test("returns the correct tagName", t => {
+test("returns the correct tagNames", t => {
   const testWithSchemaConfig = config.getProjectConfig("testWithSchema")
-  t.deepEqual(testWithSchemaConfig.tagName, "gql")
-  const testWithTagNameConfig = config.getProjectConfig("testWithTagName")
-  t.deepEqual(testWithTagNameConfig.tagName, "graphql")
+  t.deepEqual(testWithSchemaConfig.tagNames, ["gql"])
+  const testWithTagNamesConfig = config.getProjectConfig("testWithTagNames")
+  t.deepEqual(testWithTagNamesConfig.tagNames, ["graphql"])
 })
 
 test('returns config for file', t => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,10 +14,9 @@ export type GraphQLConfigExtensions = {
 
 export type GraphQLResolvedConfigData = {
   schemaPath: string,
-
+  tagName?: string,
   includes?: Array<string>,
   excludes?: Array<string>,
-
   extensions?: GraphQLConfigExtensions;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export type GraphQLConfigExtensions = {
 
 export type GraphQLResolvedConfigData = {
   schemaPath: string,
-  tagName?: string,
+  tagNames?: Array<string>,
   includes?: Array<string>,
   excludes?: Array<string>,
   extensions?: GraphQLConfigExtensions;


### PR DESCRIPTION
This adds support for specifying the tagged template name for
defining GraphQL queries. This is useful configuration for many tools
including eslint-plugin-graphql and graphql-language-service-server.