### PR TITLE
Add support for advanced default values for environment variables

### DIFF
--- a/docs/user-schema.md
+++ b/docs/user-schema.md
@@ -51,4 +51,15 @@ In case you want to access a running GraphQL server via its endpoint, you can pa
 schema: http://localhost:4000/graphql
 ```
 
+### Environment variables
+It is possible to load definitions from environment variables, with or without fallback values.
 
+```yaml
+schema: ${SCHEMA_FILE:./schema.json}
+```
+
+If you want to define a fallback endpoint you may wrap your value with quotation marks.
+
+```yaml
+schema: ${SCHEMA_ENDPOINT:"http://localhost:9000"}
+```

--- a/docs/user-schema.md
+++ b/docs/user-schema.md
@@ -61,5 +61,5 @@ schema: ${SCHEMA_FILE:./schema.json}
 If you want to define a fallback endpoint you may wrap your value with quotation marks.
 
 ```yaml
-schema: ${SCHEMA_ENDPOINT:"http://localhost:9000"}
+schema: ${SCHEMA_ENDPOINT:"http://localhost:4000/graphql"}
 ```

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -86,17 +86,18 @@ export async function findConfig(
 }
 
 function replaceEnv(content: string) {
-  // https://regex101.com/r/sRTYo9/1
+  // https://regex101.com/r/k9saS6/1
   // Yes:
   //  ${NAME:DEFAULT}
+  //  ${NAME:"DEFAULT"}
   //  ${NAME}
   // Not:
   //  ${NAME:}
-  const R = /\$\{([A-Z0-9_]+(\:[^\:]+)?)\}/gi;
-  return content.replace(R, (_, result) => {
-    const [name, value] = result.split(':');
+  const R = /\$\{(?<name>[A-Z0-9_]+)(\:((?<value>[^\:]+)|(\"(?<customValue>[^\"]+)\")))?\}/gi;
+  return content.replace(R, (...args) => {
+    const {name, value, customValue} = args[9];
 
-    return process.env[name] ? String(process.env[name]) : value;
+    return process.env[name] ? String(process.env[name]) : value || customValue;
   });
 }
 

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -64,6 +64,22 @@ describe('environment variables', () => {
     expect(config!.getDefault().schema).toEqual('./schema.graphql');
   });
 
+  test('not defined but with a default value inside quotation marks', async () => {
+    const url = 'http://localhost:9000';
+    temp.createFile(
+      '.graphqlrc',
+      `
+      schema: \${FOO:"${url}"}
+    `,
+    );
+
+    const config = await loadConfig({
+      rootDir: temp.dir,
+    });
+
+    expect(config!.getDefault().schema).toEqual(url);
+  });
+
   test('defined and with a default value', async () => {
     temp.createFile(
       '.graphqlrc',


### PR DESCRIPTION
Supports advanced default values using quotation marks, like endpoint urls.
Example:
```yaml
schema: ${SCHEMA_URL:"http://localhost:5000"}
```

Also, environment variable usage was added to docs.