### PR TITLE
Add support for loading the config from "package.json"

### DIFF
--- a/src/helpers/cosmiconfig.ts
+++ b/src/helpers/cosmiconfig.ts
@@ -82,6 +82,7 @@ function prepareCosmiconfig(moduleName: string, {legacy}: {legacy: boolean}) {
     '.#rc.yml',
     '.#rc.yaml',
     '.#rc.toml',
+    'package.json',
   ];
 
   if (legacy) {

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -1,5 +1,5 @@
 import {buildSchema, buildASTSchema} from 'graphql';
-import {resolve} from 'path';
+import {resolve, basename} from 'path';
 import {TempDir} from './utils/temp-dir';
 import {runTests} from './utils/runner';
 import {loadConfig, loadConfigSync} from '../src/config';
@@ -121,6 +121,65 @@ runTests({async: loadConfig, sync: loadConfigSync})((load, mode) => {
     });
   });
 
+  describe('loading from supported config files', () => {
+    const moduleName = 'graphql';
+    const schemaFile = 'schema.graphql';
+
+    const tsConfig = `export default { schema: '${schemaFile}' };`;
+    const jsConfig = `module.exports = { schema: '${schemaFile}' };`;
+    const yamlConfig = `schema: '${schemaFile}'`;
+    const tomlConfig = `schema = "${schemaFile}"`;
+    const jsonConfig = `{"schema": "${schemaFile}"}`;
+    const packageJsonConfig = `{"${moduleName}": {"schema": "${schemaFile}"}}`;
+
+    const configFiles = [
+      // #.config files
+      [`${moduleName}.config.ts`, tsConfig],
+      [`${moduleName}.config.js`, jsConfig],
+      [`${moduleName}.config.json`, jsonConfig],
+      [`${moduleName}.config.yaml`, yamlConfig],
+      [`${moduleName}.config.yml`, yamlConfig],
+      [`${moduleName}.config.toml`, tomlConfig],
+      // .#rc files
+      [`.${moduleName}rc`, yamlConfig],
+      [`.${moduleName}rc.ts`, tsConfig],
+      [`.${moduleName}rc.js`, jsConfig],
+      [`.${moduleName}rc.json`, jsonConfig],
+      [`.${moduleName}rc.yml`, yamlConfig],
+      [`.${moduleName}rc.yaml`, yamlConfig],
+      [`.${moduleName}rc.toml`, tomlConfig],
+      // other files
+      ['package.json', packageJsonConfig],
+    ];
+
+    beforeEach(() => {
+      temp.clean();
+      temp.createFile(
+        schemaFile,
+        /* GraphQL */ `
+          type Query {
+            foo: String
+          }
+        `,
+      );
+    });
+
+    test.each(configFiles)('load config from "%s"', async (name, content) => {
+      temp.createFile(name, content);
+
+      const config = await load({
+        rootDir: temp.dir,
+      });
+
+      const loadedFileName = basename(config!.filepath);
+      const loadedSchema = config!.getDefault()!.schema;
+
+      expect(config).toBeDefined();
+      expect(loadedFileName).toEqual(name);
+      expect(loadedSchema).toEqual(schemaFile);
+    });
+  });
+
   describe('environment variables', () => {
     test('not defined but with a default value', async () => {
       temp.createFile(
@@ -190,16 +249,16 @@ runTests({async: loadConfig, sync: loadConfigSync})((load, mode) => {
       temp.createFile(
         '.graphqlrc',
         `
-        projects: 
+        projects:
           foo:
             schema: ./foo.graphql
           bar:
-            schema: 
+            schema:
               - ./bar.graphql:
                 noop: true
           baz:
             schema: ./documents/**/*.graphql
-  
+
           qux:
             schema:
               - ./schemas/foo.graphql
@@ -234,7 +293,7 @@ runTests({async: loadConfig, sync: loadConfigSync})((load, mode) => {
       temp.createFile(
         '.graphqlrc',
         `
-        projects: 
+        projects:
           foo:
             schema: ./foo.graphql
             include: ./foo/*.ts
@@ -258,7 +317,7 @@ runTests({async: loadConfig, sync: loadConfigSync})((load, mode) => {
       temp.createFile(
         '.graphqlrc',
         `
-        projects: 
+        projects:
           foo:
             schema: ./foo.graphql
             include: ./foo/*.ts


### PR DESCRIPTION
## Description

This PR enables loading the configuration from the `package.json` file. This is one of the default locations `cosmiconfig` normally looks into when searching for configurations and it is also already listed as supported in the [`graphql-config` documentation](https://graphql-config.com/usage).

Fixes #692

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tests have been added to the test suite.

**Test Environment**:
- OS: Windows 10 Enterprise | OS Version: 20H2 | OS Build: 19042.985
- GraphQL Config Version: 3.2.0
- NodeJS: v14.16.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Some of the new tests fail because of another newly discovered issue in an upstream package: https://github.com/EndemolShineGroup/cosmiconfig-typescript-loader/issues/134
