### PR TITLE
feat: Add support for graphql.config.cjs

### DIFF
--- a/.changeset/small-tables-sniff.md
+++ b/.changeset/small-tables-sniff.md
@@ -1,0 +1,5 @@
+---
+'graphql-config': minor
+---
+
+feat: support `graphql.config.cjs` config

--- a/src/helpers/cosmiconfig.ts
+++ b/src/helpers/cosmiconfig.ts
@@ -54,8 +54,9 @@ function prepareCosmiconfig(moduleName: string, { legacy }: { legacy: boolean })
   const loadJson = createCustomLoader(defaultLoaders['.json']);
 
   const searchPlaces = [
-    `#.config.ts`,
-    `#.config.js`,
+    '#.config.ts',
+    '#.config.js',
+    '#.config.cjs',
     '#.config.json',
     '#.config.yaml',
     '#.config.yml',
@@ -82,6 +83,7 @@ function prepareCosmiconfig(moduleName: string, { legacy }: { legacy: boolean })
     loaders: {
       '.ts': loadTs,
       '.js': defaultLoaders['.js'],
+      '.cjs': defaultLoaders['.cjs'],
       '.json': loadJson,
       '.yaml': loadYaml,
       '.yml': loadYaml,

--- a/src/helpers/cosmiconfig.ts
+++ b/src/helpers/cosmiconfig.ts
@@ -83,7 +83,6 @@ function prepareCosmiconfig(moduleName: string, { legacy }: { legacy: boolean })
     loaders: {
       '.ts': loadTs,
       '.js': defaultLoaders['.js'],
-      '.cjs': defaultLoaders['.cjs'],
       '.json': loadJson,
       '.yaml': loadYaml,
       '.yml': loadYaml,

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -124,6 +124,7 @@ runTests({ async: loadConfig, sync: loadConfigSync })((load, mode) => {
       // #.config files
       [`${moduleName}.config.ts`, tsConfig],
       [`${moduleName}.config.js`, jsConfig],
+      [`${moduleName}.config.cjs`, jsConfig],
       [`${moduleName}.config.json`, jsonConfig],
       [`${moduleName}.config.yaml`, yamlConfig],
       [`${moduleName}.config.yml`, yamlConfig],


### PR DESCRIPTION
## Description

Using a **graphql.config.cjs** configuration file would result in an error:  
`GraphQL Config file is not available in the provided config directory: /project`

I tried using a **graphql.config.js** at first but that resulted in:
```
Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /project/graphql.config.js
require() of ES modules is not supported.
require() of /project/graphql.config.js from ~/.vscode/extensions/graphql.vscode-graphql-0.3.41/out/server/server.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename graphql.config.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /project/package.json.

```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I've rebuild the vscode-graphql extenstion with this fix applied and it worked.

**Test Environment**:
- OS: macOs
- GraphQL Config Version: master + fix
- NodeJS: v17.5.0

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (code is trivial)
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (cosmiconfig does the heavy lifting)
- [ ] New and existing unit tests and linter rules pass locally with my changes (fixed some unneeded backticks)
- [ ] Any dependent changes have been merged and published in downstream modules

