### PR TITLE
fix(loaders): conflict with codegen also using TypeScriptLoader(), causing a double ts-node register.

### DIFF
--- a/.changeset/lazy-pens-join.md
+++ b/.changeset/lazy-pens-join.md
@@ -1,0 +1,5 @@
+---
+'graphql-config': patch
+---
+
+conflict with codegen also using TypeScriptLoader(), causing a double ts-node register.

--- a/src/helpers/cosmiconfig.ts
+++ b/src/helpers/cosmiconfig.ts
@@ -81,7 +81,7 @@ function prepareCosmiconfig(moduleName: string, { legacy }: { legacy: boolean })
   return {
     searchPlaces: searchPlaces.map((place) => place.replace('#', moduleName)),
     loaders: {
-      '.ts': TypeScriptLoader(),
+      '.ts': TypeScriptLoader({ transpileOnly: true }),
       '.js': defaultLoaders['.js'],
       '.json': loadJson,
       '.yaml': loadYaml,


### PR DESCRIPTION

https://github.com/dotansimha/graphql-code-generator/pull/8452