### PR TITLE
fix(deps): add missing `@types/node` and `typescript` peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,13 +55,15 @@
     "@graphql-tools/merge": "^8.2.6",
     "@graphql-tools/url-loader": "^7.9.7",
     "@graphql-tools/utils": "^8.6.5",
+    "@types/node": "^16.11.65",
     "cosmiconfig": "7.0.1",
     "cosmiconfig-toml-loader": "1.0.0",
     "cosmiconfig-typescript-loader": "^4.0.0",
     "minimatch": "4.2.1",
     "ts-node": "^10.8.1",
     "string-env-interpolation": "1.0.1",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.0",
+    "typescript": "~4.8.4"
   },
   "devDependencies": {
     "@babel/core": "7.19.3",
@@ -70,7 +72,6 @@
     "@changesets/cli": "2.25.0",
     "@changesets/changelog-github": "0.4.7",
     "@types/jest": "28.1.8",
-    "@types/node": "16.11.65",
     "@typescript-eslint/eslint-plugin": "5.40.0",
     "@typescript-eslint/parser": "5.40.0",
     "babel-jest": "28.1.3",
@@ -87,7 +88,6 @@
     "prettier": "2.7.1",
     "rimraf": "3.0.2",
     "ts-jest": "28.0.8",
-    "typescript": "4.8.4",
     "typescript-json-schema": "0.54.0"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1801,7 +1801,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node@*", "@types/node@16.11.65", "@types/node@^16.9.2":
+"@types/node@*", "@types/node@^16.11.65", "@types/node@^16.9.2":
   version "16.11.65"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.65.tgz#59500b86af757d6fcabd3dec32fecb6e357d7a45"
   integrity sha512-Vfz7wGMOr4jbQGiQHVJm8VjeQwM9Ya7mHe9LtQ264/Epf5n1KiZShOFqk++nBzw6a/ubgYdB9Od7P+MH/LjoWw==
@@ -5791,15 +5791,15 @@ typescript-json-schema@0.54.0:
     typescript "~4.6.0"
     yargs "^17.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
-
 typescript@~4.6.0:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+
+typescript@~4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Description

This PR adds `@types/node` and `typescript`, which are required peer dependencies of `cosmiconfig-typescript-loader` and `ts-node`.

Fixes https://github.com/kamilkisiela/graphql-config/issues/1177.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

N/A

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A