### PR TITLE
Support ESM and .mts/.cts config extensions

### DIFF
--- a/src/helpers/cosmiconfig.ts
+++ b/src/helpers/cosmiconfig.ts
@@ -1,4 +1,9 @@
+import { execSync } from 'child_process';
 import { cosmiconfig, cosmiconfigSync, Loader, defaultLoaders } from 'cosmiconfig';
+import { createHash } from 'crypto';
+import { promises } from 'fs';
+import { tmpdir } from 'os';
+import { basename, join } from 'path';
 import { env } from 'string-env-interpolation';
 
 export interface ConfigSearchResult {
@@ -39,11 +44,69 @@ export function createCosmiConfigSync(moduleName: string, legacy: boolean) {
   return cosmiconfigSync(moduleName, options);
 }
 
-const loadTypeScript: Loader = (...args) => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { TypeScriptLoader } = require('cosmiconfig-typescript-loader');
-  return TypeScriptLoader({ transpileOnly: true })(...args);
+const loadTypeScript: Loader = async (filepath, content) => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { TypeScriptLoader } = require('cosmiconfig-typescript-loader');
+    return TypeScriptLoader({ transpileOnly: true })(filepath, content);
+  } catch (err) {
+    if (isRequireESMError(err)) {
+      const hash = createHash('sha256').update(content).digest('base64url');
+
+      const tempDir = join(tmpdir(), `graphql-config`);
+
+      let inTempDir: string[] = [];
+      try {
+        inTempDir = await promises.readdir(tempDir);
+      } catch (err) {
+        if (err.code === 'ENOENT') {
+          // tsc will create the directory if it doesn't exist.
+        } else {
+          throw err;
+        }
+      }
+
+      let outDir = join(tempDir, new Date().getTime() + '-' + hash);
+      const previousOutDir = inTempDir.find((s) => s.endsWith(hash));
+
+      if (previousOutDir) {
+        outDir = join(tempDir, previousOutDir);
+      } else {
+        // We're compiling the file, because ts-node doesn't work perfectly with ESM.
+        execSync(`tsc ${filepath} --module commonjs --outDir ${outDir} --skipLibCheck`);
+      }
+
+      const newPath = join(outDir, basename(filepath).replace(/\.(m|c)?ts$/, '.js'));
+      const config = import(newPath).then((m) => {
+        const config = m.default;
+        return 'default' in config ? config.default : config;
+      });
+
+      // If the cache has more than 10 files, we delete the oldest one.
+      await removeOldestDirInCache(inTempDir, tempDir, 10);
+
+      return config;
+    }
+    throw err;
+  }
 };
+
+async function removeOldestDirInCache(inTempDir: string[], tempDir: string, cacheLimit: number) {
+  if (inTempDir.length > cacheLimit) {
+    const oldest = inTempDir.sort((a, b) => {
+      const aTime = Number(a.split('-')[0]);
+      const bTime = Number(b.split('-')[0]);
+
+      return aTime - bTime;
+    })[0];
+
+    await promises.rm(join(tempDir, oldest), { recursive: true, force: true });
+  }
+}
+
+function isRequireESMError(err: any) {
+  return typeof err.stack === 'string' && err.stack.startsWith('Error [ERR_REQUIRE_ESM]:');
+}
 
 const loadToml: Loader = (...args) => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -83,6 +146,8 @@ function prepareCosmiconfig(moduleName: string, legacy: boolean) {
     searchPlaces: searchPlaces.map((place) => place.replace('#', moduleName)),
     loaders: {
       '.ts': loadTypeScript,
+      '.mts': loadTypeScript,
+      '.cts': loadTypeScript,
       '.js': defaultLoaders['.js'],
       '.json': createCustomLoader(defaultLoaders['.json']),
       '.yaml': loadYaml,


### PR DESCRIPTION
## Description

This is related to issues in `graphql-code-generator`: https://github.com/dotansimha/graphql-code-generator/issues/8509 and https://github.com/dotansimha/graphql-code-generator/issues/8862. More context in this PR: https://github.com/dotansimha/graphql-code-generator/pull/9086, https://github.com/dotansimha/graphql-code-generator/pull/9094

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Only manually so far. Probably need to add some tests.

**Test Environment**:

- OS: macOS
- GraphQL Config Version: newest
- NodeJS: 19.x

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules