### PR TITLE
should not throw `pattern is too long` from minimatch dependency when SDL schema contain more than 65536 characters

### DIFF
--- a/.changeset/seven-steaks-melt.md
+++ b/.changeset/seven-steaks-melt.md
@@ -1,0 +1,5 @@
+---
+'graphql-config': patch
+---
+
+should not throw `pattern is too long` from minimatch dependency when SDL schema contain more than 65536 characters

--- a/src/project-config.ts
+++ b/src/project-config.ts
@@ -191,7 +191,11 @@ export class GraphQLProjectConfig {
   }
 }
 
-// XXX: it works but uses nodejs - expose normalization of file and dir paths in config
+function isSDLSchemaLike(schema: string): boolean {
+  return schema.includes('\n');
+}
+
+// XXX: it works but uses Node.js - expose normalization of file and dir paths in config
 function match(filepath: string, dirpath: string, pointer?: Pointer): boolean {
   if (!pointer) {
     return false;
@@ -202,6 +206,10 @@ function match(filepath: string, dirpath: string, pointer?: Pointer): boolean {
   }
 
   if (typeof pointer === 'string') {
+    if (isSDLSchemaLike(pointer)) {
+      return false;
+    }
+
     const normalizedFilepath = normalize(isAbsolute(filepath) ? relative(dirpath, filepath) : filepath);
     return minimatch(normalizedFilepath, normalize(pointer), { dot: true });
   }

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -2,8 +2,7 @@ import { buildSchema, buildASTSchema } from 'graphql';
 import { resolve, basename } from 'path';
 import { TempDir } from './utils/temp-dir';
 import { runTests } from './utils/runner';
-import { loadConfig, loadConfigSync, ConfigNotFoundError } from 'graphql-config';
-import { beforeEach, beforeAll, test, describe, expect, afterAll } from 'vitest';
+import { loadConfig, loadConfigSync, ConfigNotFoundError, GraphQLConfig } from 'graphql-config';
 
 const temp = new TempDir();
 
@@ -375,5 +374,17 @@ runTests({ async: loadConfig, sync: loadConfigSync })((load, mode) => {
 
       expect(config.getDefault().schema).toEqual(schemaFile);
     });
+  });
+});
+
+describe('GraphQLConfig', () => {
+  const MINIMATCH_MAX_LENGTH = 65_536;
+
+  // https://github.com/dimaMachina/graphql-eslint/issues/2046
+  it(`should not throw \`pattern is too long\` from minimatch dependency when SDL schema contain more than ${MINIMATCH_MAX_LENGTH} characters`, async () => {
+    const schema = Array.from({ length: 2_150 }, (_, i) => `type Query${i} { foo: String }`).join('\n');
+    const graphQLConfig = new GraphQLConfig({ config: { schema }, filepath: '' }, []);
+    expect(schema.length).toBeGreaterThan(MINIMATCH_MAX_LENGTH);
+    expect(() => graphQLConfig.getProjectForFile('foo')).not.toThrow();
   });
 });

--- a/test/loaders.spec.ts
+++ b/test/loaders.spec.ts
@@ -1,6 +1,5 @@
 import { DirectiveDefinitionNode, buildSchema, GraphQLSchema, Kind } from 'graphql';
 import { Loader, Source } from '@graphql-tools/utils';
-import { beforeAll, test, describe, expect, vi, Mock } from 'vitest';
 import { LoadersRegistry } from 'graphql-config';
 import { loadTypedefsSync, loadSchemaSync, loadSchema, LoadSchemaOptions } from '@graphql-tools/load';
 

--- a/test/loaders.spec.ts
+++ b/test/loaders.spec.ts
@@ -1,6 +1,7 @@
 import { DirectiveDefinitionNode, buildSchema, GraphQLSchema, Kind } from 'graphql';
 import { Loader, Source } from '@graphql-tools/utils';
 import { LoadersRegistry } from 'graphql-config';
+import { Mock } from 'vitest';
 import { loadTypedefsSync, loadSchemaSync, loadSchema, LoadSchemaOptions } from '@graphql-tools/load';
 
 vi.mock('@graphql-tools/load', async () => {

--- a/test/utils/runner.ts
+++ b/test/utils/runner.ts
@@ -1,5 +1,3 @@
-import { describe } from 'vitest';
-
 type PromiseOf<T extends (...args: any[]) => any> = T extends (...args: any[]) => Promise<infer R> ? R : ReturnType<T>;
 
 export function runTests<
@@ -27,8 +25,8 @@ export function runTests<
       }, 'sync');
     });
     // async
-    describe(`async`, () => {
-      testRunner((...args) => executeAsync(...args) as any, 'async');
+    describe('async', () => {
+      testRunner(executeAsync as any, 'async');
     });
   };
 }

--- a/test/utils/temp-dir.ts
+++ b/test/utils/temp-dir.ts
@@ -1,9 +1,9 @@
-import path from 'path';
+import path from 'node:path';
 import { deleteSync } from 'del';
 import makeDir from 'make-dir';
 import parentModule from 'parent-module';
-import os from 'os';
-import { Mock, SpyInstance } from 'vitest';
+import os from 'node:os';
+import type { Mock, MockInstance } from 'vitest';
 import fs from 'node:fs';
 
 function normalizeDirectorySlash(pathname: string): string {
@@ -60,7 +60,7 @@ export class TempDir {
     fs.writeFileSync(filePath, `${contents}\n`);
   }
 
-  getSpyPathCalls(spy: Mock | SpyInstance): string[] {
+  getSpyPathCalls(spy: Mock | MockInstance): string[] {
     const calls = spy.mock.calls;
 
     const result = calls.map((call): string => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
+    "types": ["vitest/globals"],
     "paths": {
       "graphql-config": ["./src/index.ts"]
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ const CWD = process.cwd();
 
 export default defineConfig({
   test: {
+    globals: true,
     alias: {
       'graphql-config': path.join(CWD, 'src', 'index.ts'),
       // fixes Duplicate "graphql" modules cannot be used at the same time since different


### PR DESCRIPTION
fixes https://github.com/dimaMachina/graphql-eslint/issues/2046