### PR TITLE
fix: change minimatch to version 9 for node 16+ support

### DIFF
--- a/.changeset/lazy-experts-invent.md
+++ b/.changeset/lazy-experts-invent.md
@@ -1,0 +1,5 @@
+---
+'graphql-config': patch
+---
+
+Change minimatch to version 9

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@graphql-tools/utils": "^10.0.0",
     "cosmiconfig": "^9.0.0",
     "jiti": "^1.18.2",
-    "minimatch": "^10.0.0",
+    "minimatch": "^9.0.5",
     "string-env-interpolation": "^1.0.1",
     "tslib": "^2.4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ dependencies:
     specifier: ^1.18.2
     version: 1.21.6
   minimatch:
-    specifier: ^10.0.0
-    version: 10.0.1
+    specifier: ^9.0.5
+    version: 9.0.5
   string-env-interpolation:
     specifier: ^1.0.1
     version: 1.0.1
@@ -2673,6 +2673,7 @@ packages:
     engines: {node: 20 || >=22}
     dependencies:
       brace-expansion: 2.0.1
+    dev: true
 
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2685,7 +2686,6 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: true
 
   /minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #1490

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- GraphQL Config Version:
- NodeJS: 18.20.3

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

```
This error happened while installing the dependencies of graphql-config@5.1.1

Your Node version is incompatible with "minimatch@10.0.1".

Expected version: 20 || >=22
```

https://github.com/isaacs/minimatch/issues/238#issuecomment-2269888712 supports node 16+