### PR TITLE
feat: support top-level await

### DIFF
--- a/.changeset/fresh-bikes-kneel.md
+++ b/.changeset/fresh-bikes-kneel.md
@@ -1,0 +1,5 @@
+---
+'graphql-config': patch
+---
+
+support top-level await

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -128,6 +128,25 @@ runTests({ async: loadConfig, sync: loadConfigSync })((load, mode) => {
       ['package.json', packageJsonConfig],
     ];
 
+    if (mode === 'async') {
+      const topAwaitConfigTs = `await Promise.resolve(); export default { schema: '${schemaFilename}' } satisfies any`;
+      const topAwaitConfig = `await Promise.resolve(); export default { schema: '${schemaFilename}' }`;
+
+      configFiles.push(
+        // #.config files
+        [`${moduleName}.config.ts`, topAwaitConfigTs, typeModule],
+        [`${moduleName}.config.js`, topAwaitConfig, typeModule],
+        [`${moduleName}.config.mts`, topAwaitConfigTs],
+        [`${moduleName}.config.mjs`, topAwaitConfig],
+
+        // .#rc files
+        [`.${moduleName}rc.ts`, topAwaitConfigTs, typeModule],
+        [`.${moduleName}rc.js`, topAwaitConfig, typeModule],
+        [`.${moduleName}rc.mts`, topAwaitConfigTs],
+        [`.${moduleName}rc.mjs`, topAwaitConfig],
+      );
+    }
+
     beforeEach(() => {
       temp.clean();
       temp.createFile(schemaFilename, testSDL);


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Adds support for top-level await in a GraphQL config file. Includes tests.

This is good as more libraries go async-only. For us, we needed to sign a JWT in an authorization header, and we preferred to use `jose`, which is async only.

Fixes #1628.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I added new tests that run in async mode only. They're all passing, as are all existing tests.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I avoided any dependency changes, but when you do eventually upgrade `cosmiconfig` to latest, you could replace the direct usage of `jiti` with `cosmiconfig-typescript-loader`. Its latest version provides both async and sync loaders.